### PR TITLE
adopt pip_index and openapi_generator_cli_url env

### DIFF
--- a/resources/io/goharbor/run_test_case.sh
+++ b/resources/io/goharbor/run_test_case.sh
@@ -29,6 +29,8 @@ usage(){
   echo "      --gitlab-access-id        The access key ID of Gitlab registry for replication test"
   echo "      --gitlab-access-secret    The access key secret of Gitlab registry for replication test"
   echo "      --gcr-access-secret       The access secret of GCR for replication test"
+  echo "      --pip-index-url           Custom PyPI index URL passed as PIP_INDEX_URL into the test container"
+  echo "      --openapi-generator-cli-url  Custom download URL for openapi-generator-cli JAR passed into the test container"
 }
 
 # the default values
@@ -164,12 +166,26 @@ do
       shift
       shift
       ;;
+    --pip-index-url)
+      pip_index_url="$2"
+      shift
+      shift
+      ;;
+    --openapi-generator-cli-url)
+      openapi_generator_cli_url="$2"
+      shift
+      shift
+      ;;
     *)
       echo "error: unknown option $1, try $(basename "$0") -h/--help for more information"
       exit 1
       ;;
   esac
 done
+
+# fall back to environment variables inherited from the Jenkins agent shell if CLI args were not provided
+pip_index_url="${pip_index_url:-${CORP_PIP_INDEX_URL:+https://${CORP_PIP_INDEX_URL}}}"
+openapi_generator_cli_url="${openapi_generator_cli_url:-${OPENAPI_GENERATOR_CLI_URL:-}}"
 
 # TODO group the test cases by tag/label
 # test cases to runs
@@ -349,6 +365,14 @@ if [[ "${tty}" = "false" ]]; then
   docker_run_options="-i ${docker_run_options}"
 else
   docker_run_options="-it ${docker_run_options}"
+fi
+
+# pass corporate env vars into the container if set
+if [[ -n "${pip_index_url}" ]]; then
+  docker_run_options="${docker_run_options} -e PIP_INDEX_URL=${pip_index_url}"
+fi
+if [[ -n "${openapi_generator_cli_url}" ]]; then
+  docker_run_options="${docker_run_options} -e OPENAPI_GENERATOR_CLI_URL=${openapi_generator_cli_url}"
 fi
 
 docker pull ${e2e_engine_image}

--- a/src/io/goharbor/CaseSettings.groovy
+++ b/src/io/goharbor/CaseSettings.groovy
@@ -14,4 +14,6 @@ public class CaseSettings implements Serializable{
     public String gitlabAccessID // the access key ID of Gitlab registry for replication test
     public String gitlabAccessSecret // the access key secret of Gitlab registry for replication test
     public String gcrAccessSecret // the access key secret of GCR for replication test
+    public String pipIndexURL // custom PyPI index URL, e.g. https://corp.example.com/simple
+    public String openapiGeneratorCliURL // custom download URL for the openapi-generator-cli JAR
 }

--- a/vars/run_test_case.groovy
+++ b/vars/run_test_case.groovy
@@ -24,6 +24,8 @@ def call(HarborInstance instance, CaseSettings settings, String workDir){
     options = settings.gitlabAccessID ? "$options --gitlab-access-id $settings.gitlabAccessID" : options
     options = settings.gitlabAccessSecret ? "$options --gitlab-access-secret $settings.gitlabAccessSecret" : options
     options = settings.gcrAccessSecret ? "$options --gcr-access-secret \'$settings.gcrAccessSecret\'" : options
+    options = settings.pipIndexURL ? "$options --pip-index-url $settings.pipIndexURL" : options
+    options = settings.openapiGeneratorCliURL ? "$options --openapi-generator-cli-url $settings.openapiGeneratorCliURL" : options
     options = workDir ? "$options --workdir $workDir" : options
 
     sh """


### PR DESCRIPTION
This pull request adds support for passing custom environment variables into the test container to better support corporate environments and custom configurations. The main changes include updating the test runner script and pipeline settings to accept and propagate new options for a custom PyPI index URL and a custom openapi-generator-cli JAR download URL.

**Support for custom test container environment variables:**

* Added new command-line options `--pip-index-url` and `--openapi-generator-cli-url` to the `run_test_case.sh` script, allowing users to specify a custom PyPI index URL and openapi-generator-cli JAR download URL. These are now included in the usage/help output.
* Updated argument parsing in `run_test_case.sh` to handle the new options, with fallback to environment variables if CLI arguments are not provided.
* Modified the Docker run invocation in `run_test_case.sh` to pass the `PIP_INDEX_URL` and `OPENAPI_GENERATOR_CLI_URL` environment variables into the container when set.

**Pipeline and settings integration:**

* Extended the `CaseSettings` class to include `pipIndexURL` and `openapiGeneratorCliURL` fields for use in pipeline configuration.
* Updated the `run_test_case.groovy` pipeline step to pass the new settings as command-line options to the test runner script.